### PR TITLE
For GOD's sake...

### DIFF
--- a/atl-list.h
+++ b/atl-list.h
@@ -3,7 +3,7 @@
  ************************/
 
 char *level_name[]={
-	"OTROK","OBCAN","VOJAK","BOJOVNIK","MUDRC","KNAZ","MAG","KRAL","BOH","SASO","OBCAN",
+	"OTROK","OBCAN","VOJAK","BOJOVNIK","MUDRC","KNAZ","MAG","KRAL","BOH","SASO","GOD",
 	"*"
 };
 


### PR DESCRIPTION
Fix the name of "GOD" on the ranks list.
This is needed, because the database's config table is being populated with
some things setted up as 'level GOD', which isn't found otherwise.
There are other ways of fixing this, but this one seemed the most sensible to
me.